### PR TITLE
update the permit directive to match Go convention

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 SHELL=bash
 
 test:
-	cd examples && diff <(sed 's|CURDIR|$(CURDIR)|' expected_results.txt) <(go run .. 2>&1)
+	cd examples && diff <(sed 's|CURDIR|$(CURDIR)|' expected_results.txt) <(go run .. 2>&1 | sed '/^go: downloading/d')

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To prevent leaving format statements and temporary statements such as Ginkgo FIt
 
 ## Ignoring issues
 
-You can ignore a particular issue by including the directive `// permit` on that line
+You can ignore a particular issue by including the directive `//permit` on that line
 
 ## Contributing
 

--- a/examples/example.go
+++ b/examples/example.go
@@ -4,5 +4,5 @@ import "fmt"
 
 func Foo() {
 	fmt.Println("here I am")
-	fmt.Printf("this is ok") // permit:fmt.Printf // this is ok
+	fmt.Printf("this is ok") //permit:fmt.Printf // this is ok
 }

--- a/examples/expected_results.txt
+++ b/examples/expected_results.txt
@@ -1,1 +1,1 @@
-use of `fmt.Println` forbidden by pattern `^fmt\.Print(|f|ln)$` at /Users/andrewbrown/Projects/forbidigo/examples/example.go:6:2
+use of `fmt.Println` forbidden by pattern `^fmt\.Print(|f|ln)$` at CURDIR/examples/example.go:6:2

--- a/forbidigo/forbidigo.go
+++ b/forbidigo/forbidigo.go
@@ -91,7 +91,7 @@ type visitor struct {
 }
 
 func (l *Linter) Run(fset *token.FileSet, nodes ...ast.Node) ([]Issue, error) {
-	var issues []Issue // nolint:prealloc // we don't know how many there will be
+	var issues []Issue //nolint:prealloc // we don't know how many there will be
 	for _, node := range nodes {
 		var comments []*ast.CommentGroup
 		isTestFile := false
@@ -182,10 +182,10 @@ func (v *visitor) permit(node ast.Node) bool {
 		return false
 	}
 	nodePos := v.fset.Position(node.Pos())
-	var nolint = regexp.MustCompile(fmt.Sprintf(`^permit:%s\b`, regexp.QuoteMeta(v.textFor(node))))
+	var nolint = regexp.MustCompile(fmt.Sprintf(`^//\s?permit:%s\b`, regexp.QuoteMeta(v.textFor(node))))
 	for _, c := range v.comments {
 		commentPos := v.fset.Position(c.Pos())
-		if commentPos.Line == nodePos.Line && nolint.MatchString(c.Text()) {
+		if commentPos.Line == nodePos.Line && len(c.List) > 0 && nolint.MatchString(c.List[0].Text) {
 			return true
 		}
 	}

--- a/forbidigo/forbidigo_test.go
+++ b/forbidigo/forbidigo_test.go
@@ -35,6 +35,16 @@ func foo() {
 package bar
 
 func foo() {
+	fmt.Printf("here i am") //permit:fmt.Printf
+}`)
+	})
+
+	t.Run("allows old notation for explicitly permitting otherwise forbidden identifiers", func(t *testing.T) {
+		linter, _ := NewLinter([]string{`fmt\.Printf`})
+		expectIssues(t, linter, `
+package bar
+
+func foo() {
 	fmt.Printf("here i am") // permit:fmt.Printf
 }`)
 	})
@@ -45,7 +55,7 @@ func foo() {
 package bar
 
 func foo() {
-	fmt.Printf("here i am") // permit:fmt.Printf
+	fmt.Printf("here i am") //permit:fmt.Printf
 }`)
 		assert.NotEmpty(t, issues)
 	})

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func main() {
 		log.Fatalf("Could not create linter: %s", err)
 	}
 
-	var issues []forbidigo.Issue // nolint:prealloc // we don't know how many there will be
+	var issues []forbidigo.Issue //nolint:prealloc // we don't know how many there will be
 	for _, p := range pkgs {
 		nodes := make([]ast.Node, 0, len(p.Syntax))
 		for _, n := range p.Syntax {


### PR DESCRIPTION
directives should start without spaces, so `// permit` should be `//permit`.

I've added tests and updated documentation for the directives, but left in the support for the old notation.

References:

[Compiler Directives](https://golang.org/cmd/compile/#hdr-Compiler_Directives) in the golang compile command documentation.
> The compiler accepts directives in the form of comments. To distinguish them from non-directive comments, directives require no space between the comment opening and the name of the directive.


[False positives](https://golangci-lint.run/usage/false-positives/) in the golangci-lint documentation.
> Use `//nolint` instead of `// nolint` because machine-readable comments should have no space by Go convention.
