### PR TITLE
Fix readme comment example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A larger set of interesting patterns might include:
 * `^fmt\.Errorf$` -- forbid Errorf in favor of using github.com/pkg/errors
 * `^ginkgo\.F[A-Z].*$` -- forbid ginkgo focused commands (used for debug issues)
 * `^spew\.Dump$` -- forbid dumping detailed data to stdout
-* `^fmt\.Errorf(# please use github.com/pkg/errors)?$` -- forbid Errorf, with a custom message
+* `^fmt\.Errorf(# please use github\.com/pkg/errors)?$` -- forbid Errorf, with a custom message
 
 Note that the linter has no knowledge of what packages were actually imported, so aliased imports will match these patterns.
 


### PR DESCRIPTION
Regex special characters like `.` must be escaped for the whole comment
string to be treated as one group, otherwise the comment is truncated.

---

Ironically, the example I introduced in my last PR (https://github.com/ashanbrown/forbidigo/pull/11) doesn't work! I'll look into PR'ing the golangci-lint docs site too.