### PR TITLE
per-file patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ The full pattern struct has the following fields:
 * `package`: a regular expression for the full package import path. The package
   path includes the package version if the package has a version >= 2. This is
   only supported when `analyze_types` is enabled.
+* `ignore`: a list of [file glob
+  strings](https://github.com/bmatcuk/doublestar#patterns). If a glob string
+  matches `<package>/<file name>`, the pattern is ignored for the file that is
+  being analyzed. A glob string that starts with `!` reverts that. All glob
+  strings are checked one-by-one and the end result is then used to decide
+  whether the pattern applies.
 
 To distinguish such patterns from traditional regular expression patterns, the
 encoding must start with a `{` or contain line breaks. When using just JSON
@@ -121,6 +127,7 @@ isn't necessary. The following pattern strings are equivalent:
 A larger set of interesting patterns might include:
 
 -* `^fmt\.Print.*$` -- forbid use of Print statements because they are likely just for debugging
+-* `{pattern: ^fmt\.Print.*$ ignore: ["**/main.go"]}` -- forbid use of Print statements in all files except main.go
 -* `^fmt\.Errorf$` -- forbid Errorf in favor of using github.com/pkg/errors
 -* `^ginkgo\.F[A-Z].*$` -- forbid ginkgo focused commands (used for debug issues)
 -* `^spew\.Dump$` -- forbid dumping detailed data to stdout

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/ashanbrown/forbidigo
 go 1.12
 
 require (
+	github.com/bmatcuk/doublestar/v4 v4.6.0 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/tools v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/bmatcuk/doublestar/v4 v4.6.0 h1:HTuxyug8GyFbRkrffIpzNCSK4luc0TY3wzXvzIZhEXc=
+github.com/bmatcuk/doublestar/v4 v4.6.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/main.go
+++ b/main.go
@@ -61,7 +61,7 @@ func main() {
 		for _, n := range p.Syntax {
 			nodes = append(nodes, n)
 		}
-		newIssues, err := linter.RunWithConfig(forbidigo.RunConfig{Fset: p.Fset, TypesInfo: p.TypesInfo}, nodes...)
+		newIssues, err := linter.RunWithConfig(forbidigo.RunConfig{Fset: p.Fset, TypesInfo: p.TypesInfo, Pkg: p.Types}, nodes...)
 		if err != nil {
 			log.Fatalf("failed: %s", err)
 		}

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -76,7 +76,7 @@ func (a *analyzer) runAnalysis(pass *analysis.Pass) (interface{}, error) {
 	for _, f := range pass.Files {
 		nodes = append(nodes, f)
 	}
-	config := forbidigo.RunConfig{Fset: pass.Fset, DebugLog: a.debugLog}
+	config := forbidigo.RunConfig{Fset: pass.Fset, DebugLog: a.debugLog, Pkg: pass.Pkg}
 	if a.expand {
 		config.TypesInfo = pass.TypesInfo
 	}

--- a/pkg/analyzer/analyzer_test.go
+++ b/pkg/analyzer/analyzer_test.go
@@ -11,7 +11,7 @@ func TestLiteralAnalyzer(t *testing.T) {
 	testdata := analysistest.TestData()
 	patterns := append(forbidigo.DefaultPatterns(),
 		`^pkg\.Forbidden$`,
-		`^Shiny`,
+		`{p: ^Shiny, ignore: ["**/ignored.go"]}`,
 		`^AlsoShiny`,
 		`^renamed\.Forbidden`,
 	)

--- a/pkg/analyzer/testdata/src/matchtext/ignored.go
+++ b/pkg/analyzer/testdata/src/matchtext/ignored.go
@@ -1,0 +1,7 @@
+package testdata
+
+import (
+	. "example.com/some/thing"
+)
+
+var _ = Shiny


### PR DESCRIPTION
Including the `<package>:<file>` prefix as alternative text that gets matched
against makes it possible to write patterns that only match when that prefix is
as intended.

This builds on top of https://github.com/ashanbrown/forbidigo/pull/21 which must be merged first.