### PR TITLE
Fix pattern struct yaml names

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ The full pattern struct has the following fields:
 
 * `msg`: an additional comment that gets added to the error message when a
   pattern matches.
-* `pattern`: the regular expression that matches the source code or expanded
+* `p`: the regular expression that matches the source code or expanded
   expression, depending on the global flag.
-* `package`: a regular expression for the full package import path. The package
+* `pkg`: a regular expression for the full package import path. The package
   path includes the package version if the package has a version >= 2. This is
   only supported when `analyze_types` is enabled.
 


### PR DESCRIPTION
I noticed that the names of the struct attributes in the readme didn't line up with the examples below the description, so found the [actual struct](https://github.com/ashanbrown/forbidigo/blob/ffe9bcb4b91f70d269223442b07cc9227fdf43dc/forbidigo/patterns.go#L13-L29) and changed the README to line up with the yaml tags.