### PR TITLE
Ensure we match types within selector

### DIFF
--- a/forbidigo/forbidigo.go
+++ b/forbidigo/forbidigo.go
@@ -1,4 +1,4 @@
-// forbidigo provides a linter for forbidding the use of specific identifiers
+// Package forbidigo provides a linter for forbidding the use of specific identifiers
 package forbidigo
 
 import (
@@ -246,37 +246,36 @@ func (v *visitor) textFor(node ast.Node) string {
 func (v *visitor) expandMatchText(node ast.Node, srcText string) (matchTexts []string, pkgText string) {
 	// The text to match against is the literal source code if we cannot
 	// come up with something different.
-	matchText := srcText
+	matchTexts = []string{srcText}
 
 	if !v.cfg.AnalyzeTypes || v.runConfig.TypesInfo == nil {
-		return []string{matchText}, pkgText
+		return matchTexts, pkgText
 	}
 
 	location := v.runConfig.Fset.Position(node.Pos())
 
 	switch node := node.(type) {
 	case *ast.Ident:
-		object, ok := v.runConfig.TypesInfo.Uses[node]
-		if !ok {
+		if object, ok := v.runConfig.TypesInfo.Uses[node]; !ok {
 			// No information about the identifier. Should
 			// not happen, but perhaps there were compile
 			// errors?
 			v.runConfig.DebugLog("%s: unknown identifier %q", location, srcText)
-			return []string{matchText}, pkgText
-		}
-		if pkg := object.Pkg(); pkg != nil {
+		} else if pkg := object.Pkg(); pkg != nil {
 			pkgText = pkg.Path()
-			// if this is s a method, don't include the package name
+			// if this is a method, don't include the package name
+			isMethod := false
 			if signature, ok := object.Type().(*types.Signature); ok && signature.Recv() != nil {
-				return []string{matchText}, pkgText
+				isMethod = true
 			}
-			v.runConfig.DebugLog("%s: identifier: %q -> %q in package %q", location, srcText, matchText, pkgText)
+			v.runConfig.DebugLog("%s: identifier: %q -> %q in package %q", location, srcText, matchTexts, pkgText)
 			// match either with or without package name
-			return []string{pkg.Name() + "." + srcText, srcText}, pkgText
+			if !isMethod {
+				matchTexts = []string{pkg.Name() + "." + srcText, srcText}
+			}
 		} else {
-			v.runConfig.DebugLog("%s: identifier: %q -> %q without package", location, srcText, matchText)
+			v.runConfig.DebugLog("%s: identifier: %q -> %q without package", location, srcText, matchTexts)
 		}
-		return []string{matchText}, pkgText
 	case *ast.SelectorExpr:
 		selector := node.X
 		field := node.Sel.Name
@@ -289,10 +288,9 @@ func (v *visitor) expandMatchText(node ast.Node, srcText string) (matchTexts []s
 			if !ok {
 				v.runConfig.DebugLog("%s: selector %q with supported type %T", location, selectorText, typeAndValue.Type)
 			}
-			matchText = m + "." + field
+			matchTexts = []string{m + "." + field}
 			pkgText = p
-			v.runConfig.DebugLog("%s: selector %q with supported type %q: %q -> %q, package %q", location, selectorText, typeAndValue.Type.String(), srcText, matchText, pkgText)
-			return []string{matchText}, pkgText
+			v.runConfig.DebugLog("%s: selector %q with supported type %q: %q -> %q, package %q", location, selectorText, typeAndValue.Type.String(), srcText, matchTexts, pkgText)
 		}
 		// Some expressions need special treatment.
 		switch selector := selector.(type) {
@@ -303,34 +301,32 @@ func (v *visitor) expandMatchText(node ast.Node, srcText string) (matchTexts []s
 				// not happen, but perhaps there were compile
 				// errors?
 				v.runConfig.DebugLog("%s: unknown selector identifier %q", location, selectorText)
-				return []string{matchText}, pkgText
-			}
-			switch object := object.(type) {
-			case *types.PkgName:
-				pkgText = object.Imported().Path()
-				matchText = object.Imported().Name() + "." + field
-				v.runConfig.DebugLog("%s: selector %q is package: %q -> %q, package %q", location, selectorText, srcText, matchText, pkgText)
-				return []string{matchText}, pkgText
-			case *types.Var:
-				m, p, ok := pkgFromType(object.Type())
-				if !ok {
-					v.runConfig.DebugLog("%s: selector %q is variable with unsupported type %T", location, selectorText, object.Type())
+			} else {
+				switch object := object.(type) {
+				case *types.PkgName:
+					pkgText = object.Imported().Path()
+					matchTexts = []string{object.Imported().Name() + "." + field}
+					v.runConfig.DebugLog("%s: selector %q is package: %q -> %q, package %q", location, selectorText, srcText, matchTexts, pkgText)
+				case *types.Var:
+					m, p, ok := pkgFromType(object.Type())
+					if !ok {
+						v.runConfig.DebugLog("%s: selector %q is variable with unsupported type %T", location, selectorText, object.Type())
+					}
+					matchTexts = []string{m + "." + field}
+					pkgText = p
+					v.runConfig.DebugLog("%s: selector %q is variable of type %q: %q -> %q, package %q", location, selectorText, object.Type().String(), srcText, matchTexts, pkgText)
+				default:
+					// Something else?
+					v.runConfig.DebugLog("%s: selector %q is identifier with unsupported type %T", location, selectorText, object)
 				}
-				matchText = m + "." + field
-				pkgText = p
-				v.runConfig.DebugLog("%s: selector %q is variable of type %q: %q -> %q, package %q", location, selectorText, object.Type().String(), srcText, matchText, pkgText)
-			default:
-				// Something else?
-				v.runConfig.DebugLog("%s: selector %q is identifier with unsupported type %T", location, selectorText, object)
 			}
 		default:
 			v.runConfig.DebugLog("%s: selector %q of unsupported type %T", location, selectorText, selector)
 		}
-		return []string{matchText}, pkgText
 	default:
 		v.runConfig.DebugLog("%s: unsupported type %T", location, node)
-		return []string{matchText}, pkgText
 	}
+	return matchTexts, pkgText
 }
 
 // pkgFromType tries to determine `<package name>.<type name>` and the full

--- a/pkg/analyzer/testdata/src/example.com/some/pkg/pkg.go
+++ b/pkg/analyzer/testdata/src/example.com/some/pkg/pkg.go
@@ -11,7 +11,14 @@ type CustomType struct {
 	ForbiddenField int
 }
 
-func (c CustomType) AlsoForbidden() {}
+
+type Result struct {
+	Value int
+}
+
+func (c CustomType) AlsoForbidden() *Result {
+	return nil
+}
 
 type CustomInterface interface {
 	StillForbidden()

--- a/pkg/analyzer/testdata/src/expandtext/expandtext.go
+++ b/pkg/analyzer/testdata/src/expandtext/expandtext.go
@@ -21,7 +21,7 @@ type myCustomStruct struct {
 }
 
 type myCustomInterface interface {
-	AlsoForbidden()
+	AlsoForbidden() *somepkg.Result
 }
 
 var forbiddenFunctionRef = somepkg.Forbidden // want "somepkg.Forbidden.*forbidden by pattern .*\\^pkg.*Forbidden"
@@ -39,6 +39,7 @@ func Foo() {
 
 	c := somepkg.CustomType{}
 	c.AlsoForbidden() // want "c.AlsoForbidden.*forbidden by pattern.*\\^pkg..CustomType.*Forbidden"
+	_ = c.AlsoForbidden().Value // want "c.AlsoForbidden.*forbidden by pattern.*\\^pkg..CustomType.*Forbidden"
 
 	// Selector expression with result of function call in package.
 	somepkg.NewCustom().AlsoForbidden() // want "somepkg.NewCustom...AlsoForbidden.*forbidden by pattern.*\\^pkg..CustomType.*Forbidden"

--- a/pkg/analyzer/testdata/src/matchtext/matchtext.go
+++ b/pkg/analyzer/testdata/src/matchtext/matchtext.go
@@ -21,7 +21,7 @@ type myCustomStruct struct {
 }
 
 type myCustomInterface interface {
-	AlsoForbidden()
+	AlsoForbidden() *somepkg.Result
 }
 
 var forbiddenFunctionRef = somepkg.Forbidden


### PR DESCRIPTION
Fixes #34 

The logs for this case produce:

>    forbidigo.go:282: /Users/andrew/Projects/forbidigo/pkg/analyzer/testdata/src/expandtext/expandtext.go:42:6: selector "c.AlsoForbidden().Value" with supported type "*example.com/some/pkg.Result": "c.AlsoForbidden().Value" -> "pkg.Result.Value", package "example.com/some/pkg"
