### PR TITLE
doc: Highlight go syntax in `README.md` for better readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ To distinguish such patterns from traditional regular expression patterns, the
 encoding must start with a `{` or contain line breaks. When using just JSON
 encoding, backslashes must get quoted inside strings. When using YAML, this
 isn't necessary. The following pattern strings are equivalent:
-```go
+```
 {p: "^fmt\\.Println$", msg: "do not write to stdout"}
 
 {p: ^fmt\.Println$,


### PR DESCRIPTION
# Overview
Highlight go syntax in `README.md` for better readability

## Before
![image](https://github.com/ashanbrown/forbidigo/assets/19802534/e464b0a1-c353-4ace-b910-a18796e6d883)

## After
![image](https://github.com/ashanbrown/forbidigo/assets/19802534/21c24d64-60cc-45fa-b68a-746158252da2)
