### PR TITLE
Support forbid GoStmt and  BinaryExpr pattern

### DIFF
--- a/forbidigo/forbidigo.go
+++ b/forbidigo/forbidigo.go
@@ -223,6 +223,7 @@ func (v *visitor) Visit(node ast.Node) ast.Visitor {
 	// The following two are handled below.
 	case *ast.SelectorExpr:
 	case *ast.Ident:
+	case *ast.GoStmt:
 	// Everything else isn't.
 	default:
 		return v

--- a/forbidigo/forbidigo.go
+++ b/forbidigo/forbidigo.go
@@ -224,6 +224,7 @@ func (v *visitor) Visit(node ast.Node) ast.Visitor {
 	case *ast.SelectorExpr:
 	case *ast.Ident:
 	case *ast.GoStmt:
+	case *ast.BinaryExpr:
 	// Everything else isn't.
 	default:
 		return v

--- a/pkg/analyzer/analyzer_test.go
+++ b/pkg/analyzer/analyzer_test.go
@@ -48,3 +48,18 @@ func TestExpandAnalyzer(t *testing.T) {
 	}
 	analysistest.Run(t, testdata, a, "expandtext")
 }
+
+func TestGoKeywordAnalyzer(t *testing.T) {
+	testdata := analysistest.TestData()
+	patterns := append(forbidigo.DefaultPatterns(),
+		`panic`,
+		`^go .*$`,
+	)
+	a := newAnalyzer(t.Logf)
+	for _, pattern := range patterns {
+		if err := a.Flags.Set("p", pattern); err != nil {
+			t.Fatalf("unexpected error when setting pattern: %v", err)
+		}
+	}
+	analysistest.Run(t, testdata, a, "gokeyword")
+}

--- a/pkg/analyzer/testdata/src/gokeyword/gokeyword.go
+++ b/pkg/analyzer/testdata/src/gokeyword/gokeyword.go
@@ -1,0 +1,15 @@
+package gokeyword
+
+func Do1() error {
+	return nil
+}
+
+func Do2() {
+	if err := Do1(); err != nil {
+		panic(err) // want "forbidden by pattern"
+	}
+}
+
+func Do3() {
+	go Do2() // want "forbidden by pattern"
+}


### PR DESCRIPTION
see https://github.com/ashanbrown/forbidigo/issues/47

I search the `ruleguard` and it only support func calls(maybe I'm wrong)

```bash
ruleguard -e 'm.Match(`go $x`)' x.go

ruleguard: load rules: e:5: parse match pattern: cannot parse expr: 1:18: expression in go must be function call
```
