### PR TITLE
doc: Fix installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Installation
 ```
-go get -u github.com/ashanbrown/forbidigo
+go install github.com/ashanbrown/forbidigo@latest
 ```
 
 ## Usage
@@ -31,7 +31,7 @@ identify what an expression references. This needs to be enabled through the
 `analyze_types` command line parameter. Beware this may have a performance
 impact because additional information is required for the analysis.  Note that 
 [builtin types](https://pkg.go.dev/builtin) types (`error`, `byte`, etc) are 
-considered to have the package name "" (emptry string).
+considered to have the package name "" (empty string).
 
 Replacing the literal source code works for items in a package as in the
 `fmt2.Print` example above and also for struct fields and methods. For those,


### PR DESCRIPTION
When using `go get` outside the module the following error appears:
```sh
❯ go get -u github.com/ashanbrown/forbidigo
go: go.mod file not found in current directory or any parent directory.
        'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```