### PR TITLE
chore(deps): switch from gopkg.in/yaml.v3 to go.yaml.in/yaml/v3

### DIFF
--- a/forbidigo/patterns.go
+++ b/forbidigo/patterns.go
@@ -8,7 +8,7 @@ import (
 	"regexp/syntax"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 // pattern matches code that is not supposed to be used.

--- a/forbidigo/patterns_test.go
+++ b/forbidigo/patterns_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestParseValidPatterns(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.24.0
 require (
 	github.com/google/go-cmp v0.6.0
 	github.com/stretchr/testify v1.6.0
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/tools v0.37.0
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -14,5 +14,5 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/mod v0.29.0 // indirect
 	golang.org/x/sync v0.17.0 // indirect
-	golang.org/x/sys v0.37.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/stretchr/testify v1.6.0 h1:jlIyCplCJFULU/01vCkhKuTyc3OorI3bJFuw6obfgh
 github.com/stretchr/testify v1.6.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/mod v0.12.0 h1:rmsUpXtvNzj340zd98LZ4KntptpfRHwpFOHG188oHXc=
 golang.org/x/mod v0.12.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/mod v0.29.0 h1:HV8lRxZC4l2cr3Zq1LvtOsi/ThTgWnUk/y64QSs8GwA=
 golang.org/x/mod v0.29.0/go.mod h1:NyhrlYXJ2H4eJiRy/WDBO6HMqZQ6q9nk4JzS3NuCK+w=
 golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=


### PR DESCRIPTION
gopkg.in/yaml.v3 is unmaintained, ref https://github.com/yaml/go-yaml#project-status

- 3.0.1..3.0.2 diff (3.0.1 are identical): https://gist.github.com/scop/6ec72debf62a9603cff9dc97e6814ddd
- changes after that as usual from https://github.com/yaml/go-yaml/tags

Remaining gopkg.in/yaml.v3 indirect dep comes from testify, https://github.com/stretchr/testify/pull/1772