### PR TITLE
Fix install command installing 1.x instead of 2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Installation
 ```
-go install github.com/ashanbrown/forbidigo@latest
+go install github.com/ashanbrown/forbidigo/v2@latest
 ```
 
 ## Usage


### PR DESCRIPTION
Go module name `.../v2` is different from version `@latest` part.

You need to install `/v2@latest` to get v2.x instead of latest v.1.x

This is very confusing in go and the readme docs were having users install old v1.6.0 version



```
$> go install github.com/ashanbrown/forbidigo@latest
$> go version -m "$(which forbidigo)"               
currentDir....: go1.26.5
	path	github.com/ashanbrown/forbidigo
	mod	github.com/ashanbrown/forbidigo	v1.6.0	h1:D3aewfM37Yb3pxHujIPSpTf6oQk9sc9WZi8gerOIVIY=
	dep	github.com/google/go-cmp	v0.5.6	h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
	dep	golang.org/x/mod	v0.7.0	h1:LapD9S96VoQRhi/GrNTqeBJFrUjs5UHCAtTlgwA5oZA=
	dep	golang.org/x/sys	v0.5.0	h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
	dep	golang.org/x/tools	v0.3.0	h1:SrNbZl6ECOS1qFzgTdQfWXZM9XBkiA6tkFrH9YSTPHM=
	dep	gopkg.in/yaml.v2	v2.4.0	h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
	build	-buildmode=exe
	build	-compiler=gc
	build	DefaultGODEBUG=asynctimerchan=1,containermaxprocs=0,cryptocustomrand=1,decoratemappings=0,gotestjsonbuildtext=1,gotypesalias=0,httpcookiemaxnum=0,httplaxcontentlength=1,httpmuxgo121=1,httpservecontentkeepheaders=1,multipathtcp=0,netedns0=0,panicnil=1,randseednop=0,rsa1024min=0,tls10server=1,tls3des=1,tlsmlkem=0,tlsrsakex=1,tlssecpmlkem=0,tlssha1=1,tlsunsafeekm=1,updatemaxprocs=0,urlmaxqueryparams=0,urlstrictcolons=0,winreadlinkvolume=0,winsymlink=0,x509keypairleaf=0,x509negativeserial=1,x509rsacrt=0,x509sha256skid=0,x509usepolicies=0
	build	CGO_ENABLED=1
	build	CGO_CFLAGS=
	build	CGO_CPPFLAGS=
	build	CGO_CXXFLAGS=
	build	CGO_LDFLAGS=
	build	GOARCH=arm64
	build	GOOS=darwin
	build	GOARM64=v8.0


# Install correct latest v2 version
$> go install github.com/ashanbrown/forbidigo/v2@latest
$> go version -m "$(which forbidigo)"                  
currentDir....: go1.26.5
	path	github.com/ashanbrown/forbidigo/v2
	mod	github.com/ashanbrown/forbidigo/v2	v2.3.1	h1:KAZijvQ7zeIBKbhikT4jCm0TLYXC4u78bTiLh/8JROI=
	dep	github.com/google/go-cmp	v0.6.0	h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
	dep	go.yaml.in/yaml/v3	v3.0.4	h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
	dep	golang.org/x/mod	v0.29.0	h1:HV8lRxZC4l2cr3Zq1LvtOsi/ThTgWnUk/y64QSs8GwA=
	dep	golang.org/x/sync	v0.17.0	h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
	dep	golang.org/x/tools	v0.37.0	h1:DVSRzp7FwePZW356yEAChSdNcQo6Nsp+fex1SUW09lE=
	build	-buildmode=exe
	build	-compiler=gc
	build	DefaultGODEBUG=containermaxprocs=0,cryptocustomrand=1,decoratemappings=0,tlssecpmlkem=0,tlssha1=1,updatemaxprocs=0,urlstrictcolons=0,x509sha256skid=0
	build	CGO_ENABLED=1
	build	CGO_CFLAGS=
	build	CGO_CPPFLAGS=
	build	CGO_CXXFLAGS=
	build	CGO_LDFLAGS=
	build	GOARCH=arm64
	build	GOOS=darwin
	build	GOARM64=v8.0
```